### PR TITLE
Fix barn id

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -109,7 +109,7 @@ router.post('/aggregate', (req, res) => {
             upsert: true,
             new: true
           }
-        ).then(dbArtist => filterTracksForArtist(dbArtist, artist, barn.id));
+        ).then(dbArtist => filterTracksForArtist(dbArtist, artist, barn.spotifyId));
         artistSavePromises.push(artistPromise);
       });
       return Promise.all(artistSavePromises);


### PR DESCRIPTION
Fixes error where the barn's playlist id is not stored to the database, resulting in tracks being added to the same barn multiple times.